### PR TITLE
rate_of_change and flat_line tests use time intervals 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 docs/build
 .cache/
 .anaconda
+.idea

--- a/ioos_qc/config.py
+++ b/ioos_qc/config.py
@@ -51,6 +51,8 @@ class QcConfig(object):
             for testname, kwargs in tests.items():
                 if not hasattr(testpackage, testname):
                     L.warning('No test named "{}.{}" was found, skipping'.format(modu, testname))
+                elif kwargs is None:
+                    L.debug('Test "{}.{}" had no config, skipping'.format(modu, testname))
                 else:
                     # Get our own copy of the kwargs object so we can change it
                     testkwargs = deepcopy(passedkwargs)

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -355,7 +355,7 @@ def spike_test(inp : Sequence[N],
 
     # Calculate the average of n-2 and n
     ref = np.zeros(inp.size, dtype=np.float64)
-    ref[1:-1] = np.abs((inp[0:-2] + inp[2:]) / 2)
+    ref[1:-1] = (inp[0:-2] + inp[2:]) / 2
     ref = np.ma.masked_invalid(ref)
 
     # Start with everything as passing (1)

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -2,11 +2,11 @@
 # coding=utf-8
 import logging
 import warnings
-import numpy as np
-from numbers import Real
 from collections import namedtuple
+from numbers import Real
 from typing import Sequence, Tuple, Union, Dict
 
+import numpy as np
 from pygc import great_distance
 
 from ioos_qc.utils import (
@@ -271,7 +271,7 @@ def climatology_test(config : Union[ClimatologyConfig, Sequence[Dict[str, Tuple]
     Args:
         config: A ClimatologyConfig object or a list of dicts containing tuples
             that can be used to create a ClimatologyConfig object. Dict should be composed of
-            keywords 'tspan' and 'vspan' as well as an optiona 'zspan'
+            keywords 'tspan' and 'vspan' as well as an optional 'zspan'
         tinp: Time data as a numpy array of dtype `datetime64`.
         vinp: Input data as a numeric numpy array or a list of numbers.
         zinp: Z (depth) data as a numeric numpy array or a list of numbers.
@@ -379,24 +379,21 @@ def spike_test(inp : Sequence[N],
 
 
 def rate_of_change_test(inp : Sequence[N],
-                        deviation : N,
-                        num_deviations : int = 3
+                        tinp : Sequence[N],
+                        threshold : float
                         ) -> np.ma.core.MaskedArray:
-    """Checks the difference of neighboring values against N number of standard deviations.
-
-    Checks the first order difference of a series of values to see if
-    there are any values exceeding a standard deviation threshold defined
-    by the inputs.  These are then marked as SUSPECT.  It is up to the test operator
+    """Checks the first order difference of a series of values to see if
+    there are any values exceeding a threshold defined by the inputs.
+    These are then marked as SUSPECT.  It is up to the test operator
     to determine an appropriate threshold value for the absolute difference not to
-    exceed. Threshold are expressed as a standard deviation threshold and a factor
-    controlling how many of the thresholds to tolerate before flagging.
+    exceed. Threshold is expressed as a rate in observations units per second.
     Missing and masked data is flagged as UNKNOWN.
 
     Args:
         inp: Input data as a numeric numpy array or a list of numbers.
-        deviation: The number to multiply by `num_deviations` to get the threshold value.
-        num_deviations: The number to multiple by `deviation` to get the threshold value.
-            Defaults to 3.
+        tinp: Time data as a numpy array of dtype `datetime64`.
+        threshold: A float value representing a rate of change over time,
+                 in observation units per second.
 
     Returns:
         A masked array of flag values equal in size to that of the input.
@@ -412,27 +409,22 @@ def rate_of_change_test(inp : Sequence[N],
     # Start with everything as passing (1)
     flag_arr = np.ma.ones(inp.size, dtype='uint8')
 
-    # Calculate the (n - n-1) difference.
-    diff = np.abs(inp[1:] - inp[:-1])
-    # First value set to zero (can't subtract previous element)
-    diff = np.append(
-        np.zeros(1, dtype=np.float64),
-        diff
-    )
+    # calculate rate of change in units/second
+    roc = np.ma.zeros(inp.size, dtype='float')
+    roc[1:] = np.abs(np.diff(inp) / np.diff(tinp).astype(float))
 
-    final_threshold = deviation * num_deviations
-    # If n - n-1 is greater than the set deviations, SUSPECT test
     with np.errstate(invalid='ignore'):
-        flag_arr[diff > final_threshold] = QartodFlags.SUSPECT
+        flag_arr[roc > threshold] = QartodFlags.SUSPECT
 
     # If the value is masked set the flag to MISSING
-    flag_arr[diff.mask] = QartodFlags.MISSING
+    flag_arr[inp.mask] = QartodFlags.MISSING
 
     return flag_arr.reshape(original_shape)
 
 
 def flat_line_test(inp : Sequence[N],
-                   counts : Tuple[int, int],
+                   tinp: Sequence[N],
+                   thresholds : Tuple[int, int],
                    tolerance : N = 0
                    ) -> np.ma.MaskedArray:
     """Check for consecutively repeated values within a tolerance.
@@ -441,12 +433,13 @@ def flat_line_test(inp : Sequence[N],
 
     Args:
         inp: Input data as a numeric numpy array or a list of numbers.
-        counts: 2-tuple representing the number of repetitions within `tolerance` to
-            allow before being flagged as SUSPECT or FAIL. The larger of the two
-            values is alwasy the SUSPECT threshold and the lower of the two numbers
+        tinp: Time data as a numpy array of dtype `datetime64`.
+        thresholds: 2-tuple representing the number of seconds within `tolerance` to
+            allow before being flagged as SUSPECT or FAIL. The smaller of the two
+            values is always the SUSPECT threshold and the larger of the two numbers
             is always the FAIL threshold.
         tolerance: The tolerance that should be exceeded between consecutive values.
-            If the number consecutive values occuring that don't cross over `tolerance`
+            If the number consecutive values occurring that don't cross over `tolerance`
             cross over either of the `counts` then the data will be flagged.
 
     Returns:
@@ -464,10 +457,12 @@ def flat_line_test(inp : Sequence[N],
             out[i, :data.size] = data
         return out
 
-    assert isfixedlength(counts, 2)
-    counts = span(*sorted(counts))
-    if not isinstance(counts.minv, int) or not isinstance(counts.maxv, int):
-        raise TypeError('Counts must be integers. Got {}'.format(counts))
+    assert isfixedlength(thresholds, 2)
+
+    # convert time thresholds to number of observations
+    time_interval = np.median(np.diff(tinp)).astype(float)
+    counts = thresholds / time_interval
+    counts = span(*sorted(counts.astype(int)))
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,6 +145,16 @@ class ConfigRunTest(unittest.TestCase):
             location_expected
         )
 
+    def test_with_empty_config(self):
+        self.config['qartod']['flat_line_test'] = None
+        qc = QcConfig(self.config)
+        r = qc.run(
+            inp=list(range(13))
+        )
+
+        assert 'gross_range_test' in r['qartod']
+        assert 'flat_line_test' not in r['qartod']
+
 
 class ConfigClimatologyTest(unittest.TestCase):
 

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -500,9 +500,15 @@ class QartodSpikeTest(unittest.TestCase):
 
 class QartodRateOfChangeTest(unittest.TestCase):
 
+    def setUp(self):
+        self.times = np.arange('2015-01-01 00:00:00', '2015-01-01 06:00:00',
+                               step=np.timedelta64(15, 'm'), dtype=np.datetime64)
+        self.threshold = 5 / 15 / 60  # 5 units per 15 minutes --> 5/15/60 units per second
+
     def test_rate_of_change(self):
-        arr = [2, 10, 2.1, 3, 4, 5, 7, 10, 0, 2, 2.2, 2]
-        expected = [1, 3, 3, 1, 1, 1, 1, 1, 3, 1, 1, 1]
+        times = self.times
+        arr = [2, 10, 2.1, 3, 4, 5, 7, 10, 0, 2, 2.2, 2, 1, 2, 3, 90, 91, 92, 93, 1, 2, 3, 4, 5]
+        expected = [1, 3, 3, 1, 1, 1, 1, 1, 3, 1, 1, 1, 1, 1, 1, 3, 1, 1, 1, 3, 1, 1, 1, 1]
         inputs = [
             arr,
             np.asarray(arr, dtype=np.floating),
@@ -511,46 +517,43 @@ class QartodRateOfChangeTest(unittest.TestCase):
         for i in inputs:
             result = qartod.rate_of_change_test(
                 inp=i,
-                deviation=2,
-                num_deviations=2
+                tinp=times,
+                threshold=self.threshold
             )
             npt.assert_array_equal(expected, result)
 
-        arr = [1, 2, 3, 90, 91, 92, 93, 1, 2, 3]
-        expected = [1, 1, 1, 3, 1, 1, 1, 3, 1, 1]
-        inputs = [
-            arr,
-            np.asarray(arr, dtype=np.floating),
-            da.from_array(np.asarray(arr, dtype=np.floating), chunks=2)
-        ]
-        for i in inputs:
-            result = qartod.rate_of_change_test(
-                inp=i,
-                deviation=20,
-                num_deviations=3
-            )
-            npt.assert_array_equal(expected, result)
+    def test_rate_of_change_missing_values(self):
+        times = self.times[0:8]
+        arr = [2, 10, 2, 3, None, None, 7, 10]
+        expected = [1, 3, 3, 1, 9, 9, 1, 1]
+        result = qartod.rate_of_change_test(
+            inp=arr,
+            tinp=times,
+            threshold=self.threshold
+        )
+        npt.assert_array_equal(expected, result)
 
-        arr = [1, 2, 3, 90, 91, 92, 93, 1, 2, 3]
-        expected = [1, 3, 3, 3, 3, 3, 3, 3, 3, 3]
-        inputs = [
-            arr,
-            np.asarray(arr, dtype=np.floating),
-            da.from_array(np.asarray(arr, dtype=np.floating), chunks=2)
-        ]
-        for i in inputs:
-            result = qartod.rate_of_change_test(
-                inp=i,
-                deviation=0.5,
-                num_deviations=1
-            )
-            npt.assert_array_equal(expected, result)
+    def test_rate_of_change_negative_values(self):
+        times = self.times[0:4]
+        arr = [-2, -10, -2, -3]
+        expected = [1, 3, 3, 1]
+        result = qartod.rate_of_change_test(
+            inp=arr,
+            tinp=times,
+            threshold=self.threshold
+        )
+        npt.assert_array_equal(expected, result)
 
 
 class QartodFlatLineTest(unittest.TestCase):
 
+    def setUp(self):
+        self.times = np.arange('2015-01-01 00:00:00', '2015-01-01 06:00:00',
+                               step=np.timedelta64(15, 'm'), dtype=np.datetime64)
+        self.thresholds = (3000, 4800)  # 50 mins and 80 mins
+        self.tolerance = 0.01
+
     def test_flat_line(self):
-        """Make sure flat line check returns expected flag values."""
         arr = [1, 2, 2.0001, 2, 2.0001, 2, 2.0001, 2, 4, 5, 3, 3.0001, 3.0005, 3.00001]
         expected = [1, 1, 1, 1, 3, 3, 4, 4, 1, 1, 1, 1, 1, 3]
         inputs = [
@@ -561,10 +564,23 @@ class QartodFlatLineTest(unittest.TestCase):
         for i in inputs:
             result = qartod.flat_line_test(
                 inp=i,
-                counts=(3, 5),
-                tolerance=0.01
+                tinp=self.times,
+                thresholds=self.thresholds,
+                tolerance=self.tolerance
             )
             npt.assert_array_equal(result, expected)
+
+        # test negative array - should return same result
+        arr = [-1*x for x in arr]
+        npt.assert_array_equal(
+            qartod.flat_line_test(
+                inp=arr,
+                tinp=self.times,
+                thresholds=self.thresholds,
+                tolerance=self.tolerance
+            ),
+            expected
+        )
 
         # test empty array - should return empty result
         arr = np.array([])
@@ -572,8 +588,9 @@ class QartodFlatLineTest(unittest.TestCase):
         npt.assert_array_equal(
             qartod.flat_line_test(
                 inp=arr,
-                counts=(3, 5),
-                tolerance=0.01
+                tinp=self.times,
+                thresholds=self.thresholds,
+                tolerance=self.tolerance
             ),
             expected
         )
@@ -584,13 +601,14 @@ class QartodFlatLineTest(unittest.TestCase):
         npt.assert_array_equal(
             qartod.flat_line_test(
                 inp=arr,
-                counts=(3, 5),
+                tinp=self.times,
+                thresholds=self.thresholds,
                 tolerance=0.00000000001
             ),
             expected
         )
 
-        # test missing data
+    def test_flat_line_missing_values(self):
         arr = [1, None, np.ma.masked, 2, 2.0001, 2, 2.0001, 2, 4, None, 3, None, None, 3.00001]
         expected = [1, 9, 9, 1, 3, 3, 4, 4, 1, 9, 1, 9, 9, 3]
         with warnings.catch_warnings():
@@ -603,8 +621,9 @@ class QartodFlatLineTest(unittest.TestCase):
         for i in inputs:
             result = qartod.flat_line_test(
                 inp=i,
-                counts=(3, 5),
-                tolerance=0.01
+                tinp=self.times,
+                thresholds=self.thresholds,
+                tolerance=self.tolerance
             )
             npt.assert_array_equal(result, expected)
 
@@ -615,6 +634,7 @@ class QartodFlatLineTest(unittest.TestCase):
                 np.ones(12),
                 (4.5, 6.93892)
             )
+
 
 
 class QartodAttenuatedSignalTest(unittest.TestCase):


### PR DESCRIPTION
Updates: `rate_of_change` and `flat_line` tests use time intervals instead of "counts". This makes the test more generic. For example, you can specify a rate of change threshold of `0.5 units/second` instead of `0.5 units/count` -- the latter requires either some data massaging beforehand, or threshold config specific to each data stream coming in.

Also, fixed a bug with `spike_test` when there are negative values, and allow for `QcConfig` test with no arguments.