### PR TITLE
Remove dask as requirement

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,8 +16,6 @@ requirements:
     - pip
   run:
     - python
-    - bottleneck
-    - dask
     - geojson
     - netCDF4
     - numpy >=1.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-bottleneck
-dask
 geojson
 netCDF4
 numpy>=1.14

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+dask
 pytest
 pytest-flake8
 flake8<3.7  # https://github.com/tholo/pytest-flake8/pull/59

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -4,7 +4,6 @@ import logging
 import unittest
 import warnings
 
-import dask.array as da
 import numpy as np
 import numpy.testing as npt
 
@@ -14,6 +13,16 @@ L = logging.getLogger('ioos_qc')
 L.setLevel(logging.INFO)
 L.addHandler(logging.StreamHandler())
 
+
+def dask_arr(vals):
+    """
+    If dask is enabled for this environment, return dask array of values. Otherwise, return values.
+    """
+    try:
+        import dask.array as da
+        return da.from_array(vals, chunks=2)
+    except ImportError:
+        return vals
 
 class QartodLocationTest(unittest.TestCase):
 
@@ -36,8 +45,8 @@ class QartodLocationTest(unittest.TestCase):
             np.ma.array([4, 1, 4])
         )
 
-        lon = da.from_array(lon, chunks=2)
-        lat = da.from_array(lat, chunks=2)
+        lon = dask_arr(lon)
+        lat = dask_arr(lat)
         npt.assert_array_equal(
             qartod.location_test(lon=lon, lat=lat),
             np.ma.array([4, 1, 4])
@@ -59,8 +68,8 @@ class QartodLocationTest(unittest.TestCase):
             np.ma.array([9])
         )
 
-        lon = da.from_array(lon, chunks=2)
-        lat = da.from_array(lat, chunks=2)
+        lon = dask_arr(lon)
+        lat = dask_arr(lat)
         npt.assert_array_equal(
             qartod.location_test(lon=lon, lat=lat),
             np.ma.array([9])
@@ -82,8 +91,8 @@ class QartodLocationTest(unittest.TestCase):
         )
 
         # Test dask nan input
-        lon = da.from_array(lon, chunks=2)
-        lat = da.from_array(lat, chunks=2)
+        lon = dask_arr(lon)
+        lat = dask_arr(lat)
         npt.assert_array_equal(
             qartod.location_test(lon=lon, lat=lat),
             np.ma.array([9])
@@ -121,8 +130,8 @@ class QartodLocationTest(unittest.TestCase):
             np.ma.array([4, 1, 1, 4, 4])
         )
 
-        lon = da.from_array(np.asarray([80,   -78, -71, -79, 500], dtype=np.floating), chunks=2)
-        lat = da.from_array(np.asarray([None,  50,  59,  10, -60], dtype=np.floating), chunks=2)
+        lon = dask_arr(np.asarray([80,   -78, -71, -79, 500], dtype=np.floating))
+        lat = dask_arr(np.asarray([None,  50,  59,  10, -60], dtype=np.floating))
         npt.assert_array_equal(
             qartod.location_test(lon=lon, lat=lat, bbox=[-80, 40, -70, 60]),
             np.ma.array([4, 1, 1, 4, 4])
@@ -172,8 +181,8 @@ class QartodGrossRangeTest(unittest.TestCase):
                 vals,
                 np.array(vals, dtype=np.integer),
                 np.array(vals, dtype=np.floating),
-                da.from_array(np.array(vals, dtype=np.integer), chunks=2),
-                da.from_array(np.array(vals, dtype=np.floating), chunks=2)
+                dask_arr(np.array(vals, dtype=np.integer)),
+                dask_arr(np.array(vals, dtype=np.floating))
             ]
 
         for i in inputs:
@@ -236,7 +245,7 @@ class QartodGrossRangeTest(unittest.TestCase):
             inputs = [
                 vals,
                 np.array(vals, dtype=np.floating),
-                da.from_array(np.array(vals, dtype=np.floating), chunks=2)
+                dask_arr(np.array(vals, dtype=np.floating))
             ]
 
         for i in inputs:
@@ -291,7 +300,7 @@ class QartodClimatologyTest(unittest.TestCase):
         inputs = [
             values,
             np.asarray(values, dtype=np.floating),
-            da.from_array(np.asarray(values, dtype=np.floating), chunks=2)
+            dask_arr(np.asarray(values, dtype=np.floating))
         ]
 
         for i in inputs:
@@ -328,7 +337,7 @@ class QartodClimatologyTest(unittest.TestCase):
         inputs = [
             values,
             np.asarray(values, dtype=np.floating),
-            da.from_array(np.asarray(values, dtype=np.floating), chunks=2)
+            dask_arr(np.asarray(values, dtype=np.floating))
         ]
 
         for i in inputs:
@@ -375,7 +384,7 @@ class QartodClimatologyTest(unittest.TestCase):
         inputs = [
             values,
             np.asarray(values, dtype=np.floating),
-            da.from_array(np.asarray(values, dtype=np.floating), chunks=2)
+            dask_arr(np.asarray(values, dtype=np.floating))
         ]
 
         for i in inputs:
@@ -411,7 +420,7 @@ class QartodSpikeTest(unittest.TestCase):
         inputs = [
             arr,
             np.asarray(arr, dtype=np.floating),
-            da.from_array(np.asarray(arr, dtype=np.floating), chunks=2)
+            dask_arr(np.asarray(arr, dtype=np.floating))
         ]
         for i in inputs:
             npt.assert_array_equal(
@@ -438,7 +447,7 @@ class QartodSpikeTest(unittest.TestCase):
         inputs = [
             arr,
             np.asarray(arr, dtype=np.floating),
-            da.from_array(np.asarray(arr, dtype=np.floating), chunks=2)
+            dask_arr(np.asarray(arr, dtype=np.floating))
         ]
         for i in inputs:
             npt.assert_array_equal(
@@ -464,7 +473,7 @@ class QartodSpikeTest(unittest.TestCase):
         inputs = [
             arr,
             np.asarray(arr, dtype=np.floating),
-            da.from_array(np.asarray(arr, dtype=np.floating), chunks=2)
+            dask_arr(np.asarray(arr, dtype=np.floating))
         ]
         for i in inputs:
             npt.assert_array_equal(
@@ -492,7 +501,7 @@ class QartodSpikeTest(unittest.TestCase):
         inputs = [
             arr,
             np.asarray(arr, dtype=np.floating),
-            da.from_array(np.asarray(arr, dtype=np.floating), chunks=2)
+            dask_arr(np.asarray(arr, dtype=np.floating))
         ]
         for i in inputs:
             npt.assert_array_equal(
@@ -519,7 +528,7 @@ class QartodRateOfChangeTest(unittest.TestCase):
         inputs = [
             arr,
             np.asarray(arr, dtype=np.floating),
-            da.from_array(np.asarray(arr, dtype=np.floating), chunks=2)
+            dask_arr(np.asarray(arr, dtype=np.floating))
         ]
         for i in inputs:
             result = qartod.rate_of_change_test(
@@ -567,7 +576,7 @@ class QartodFlatLineTest(unittest.TestCase):
         inputs = [
             arr,
             np.asarray(arr, dtype=np.floating),
-            da.from_array(np.asarray(arr, dtype=np.floating), chunks=2)
+            dask_arr(np.asarray(arr, dtype=np.floating))
         ]
         for i in inputs:
             result = qartod.flat_line_test(
@@ -628,7 +637,7 @@ class QartodFlatLineTest(unittest.TestCase):
             inputs = [
                 arr,
                 np.asarray(arr, dtype=np.floating),
-                da.from_array(np.asarray(arr, dtype=np.floating), chunks=2)
+                dask_arr(np.asarray(arr, dtype=np.floating))
             ]
         for i in inputs:
             result = qartod.flat_line_test(


### PR DESCRIPTION
Dask brings in a LOT of extra dependencies, and isn't required for the library itself, so removing it from dependencies. It's still listed as a test dependency, but the tests will run even if it's not installed.

Diff of dependencies: https://www.diffchecker.com/zC6gypy8

Deps before:

```

  backcall           conda-forge/noarch::backcall-0.1.0-py_0
  blas               conda-forge/linux-64::blas-1.1-openblas
  bokeh              conda-forge/linux-64::bokeh-1.0.4-py37_1000
  bottleneck         conda-forge/linux-64::bottleneck-1.2.1-py37h3010b51_1001
  bzip2              conda-forge/linux-64::bzip2-1.0.6-h14c3975_1002
  ca-certificates    conda-forge/linux-64::ca-certificates-2018.11.29-ha4d7672_0
  certifi            conda-forge/linux-64::certifi-2018.11.29-py37_1000
  cftime             conda-forge/linux-64::cftime-1.0.3.4-py37h3010b51_1000
  click              conda-forge/noarch::click-7.0-py_0
  cloudpickle        conda-forge/noarch::cloudpickle-0.7.0-py_0
  curl               conda-forge/linux-64::curl-7.64.0-h646f8bb_0
  cytoolz            conda-forge/linux-64::cytoolz-0.9.0.1-py37h14c3975_1001
  dask               conda-forge/noarch::dask-1.1.1-py_0
  dask-core          conda-forge/noarch::dask-core-1.1.1-py_0
  decorator          conda-forge/noarch::decorator-4.3.2-py_0
  distributed        conda-forge/linux-64::distributed-1.25.3-py37_0
  freetype           conda-forge/linux-64::freetype-2.9.1-h94bbf69_1005
  geojson            conda-forge/noarch::geojson-2.4.1-py_0
  hdf4               conda-forge/linux-64::hdf4-4.2.13-h9a582f1_1002
  hdf5               conda-forge/linux-64::hdf5-1.10.4-nompi_h11e915b_1105
  heapdict           conda-forge/linux-64::heapdict-1.0.0-py37_1000
  ipython            conda-forge/linux-64::ipython-7.2.0-py37h24bf2e0_1000
  ipython_genutils   conda-forge/noarch::ipython_genutils-0.2.0-py_1
  jedi               conda-forge/linux-64::jedi-0.13.2-py37_1000
  jinja2             conda-forge/noarch::jinja2-2.10-py_1
  jpeg               conda-forge/linux-64::jpeg-9c-h14c3975_1001
  krb5               conda-forge/linux-64::krb5-1.16.3-hc83ff2d_1000
  libcurl            conda-forge/linux-64::libcurl-7.64.0-h01ee5af_0
  libedit            conda-forge/linux-64::libedit-3.1.20170329-hf8c457e_1001
  libffi             conda-forge/linux-64::libffi-3.2.1-hf484d3e_1005
  libgcc-ng          conda-forge/linux-64::libgcc-ng-7.3.0-hdf63c60_0
  libgfortran-ng     conda-forge/linux-64::libgfortran-ng-7.2.0-hdf63c60_3
  libnetcdf          conda-forge/linux-64::libnetcdf-4.6.2-hbdf4f91_1001
  libpng             conda-forge/linux-64::libpng-1.6.36-h84994c4_1000
  libssh2            conda-forge/linux-64::libssh2-1.8.0-h1ad7b7a_1003
  libstdcxx-ng       conda-forge/linux-64::libstdcxx-ng-7.3.0-hdf63c60_0
  libtiff            conda-forge/linux-64::libtiff-4.0.10-h648cc4a_1001
  locket             conda-forge/noarch::locket-0.2.0-py_2
  markupsafe         conda-forge/linux-64::markupsafe-1.1.0-py37h14c3975_1000
  msgpack-python     conda-forge/linux-64::msgpack-python-0.6.1-py37h6bb024c_0
  ncurses            conda-forge/linux-64::ncurses-6.1-hf484d3e_1002
  netcdf4            conda-forge/linux-64::netcdf4-1.4.2-py37had69b76_1001
  numpy              conda-forge/linux-64::numpy-1.16.1-py37_blas_openblash1522bff_0
  olefile            conda-forge/noarch::olefile-0.46-py_0
  openblas           conda-forge/linux-64::openblas-0.3.3-h9ac9557_1001
  openssl            conda-forge/linux-64::openssl-1.0.2p-h14c3975_1002
  packaging          conda-forge/noarch::packaging-19.0-py_0
  pandas             conda-forge/linux-64::pandas-0.24.1-py37hf484d3e_0
  parso              conda-forge/noarch::parso-0.3.4-py_0
  partd              conda-forge/noarch::partd-0.3.9-py_0
  pexpect            conda-forge/linux-64::pexpect-4.6.0-py37_1000
  pickleshare        conda-forge/linux-64::pickleshare-0.7.5-py37_1000
  pillow             conda-forge/linux-64::pillow-5.4.1-py37h00a061d_1000
  pip                conda-forge/linux-64::pip-19.0.2-py37_0
  prompt_toolkit     conda-forge/noarch::prompt_toolkit-2.0.8-py_0
  psutil             conda-forge/linux-64::psutil-5.5.1-py37h14c3975_0
  ptyprocess         conda-forge/linux-64::ptyprocess-0.6.0-py37_1000
  pygc               conda-forge/noarch::pygc-1.2.1-py_1
  pygments           conda-forge/noarch::pygments-2.3.1-py_0
  pyparsing          conda-forge/noarch::pyparsing-2.3.1-py_0
  python             conda-forge/linux-64::python-3.7.1-hd21baee_1001
  python-dateutil    conda-forge/noarch::python-dateutil-2.8.0-py_0
  pytz               conda-forge/noarch::pytz-2018.9-py_0
  pyyaml             conda-forge/linux-64::pyyaml-3.13-py37h14c3975_1001
  readline           conda-forge/linux-64::readline-7.0-hf8c457e_1001
  ruamel.yaml        conda-forge/linux-64::ruamel.yaml-0.15.88-py37h14c3975_0
  setuptools         conda-forge/linux-64::setuptools-40.8.0-py37_0
  simplejson         conda-forge/linux-64::simplejson-3.16.0-py37h14c3975_1002
  six                conda-forge/linux-64::six-1.12.0-py37_1000
  sortedcontainers   conda-forge/noarch::sortedcontainers-2.1.0-py_0
  sqlite             conda-forge/linux-64::sqlite-3.26.0-h67949de_1000
  tblib              conda-forge/noarch::tblib-1.3.2-py_1
  tk                 conda-forge/linux-64::tk-8.6.9-h84994c4_1000
  toolz              conda-forge/noarch::toolz-0.9.0-py_1
  tornado            conda-forge/linux-64::tornado-5.1.1-py37h14c3975_1000
  traitlets          conda-forge/linux-64::traitlets-4.3.2-py37_1000
  wcwidth            conda-forge/noarch::wcwidth-0.1.7-py_1
  wheel              conda-forge/linux-64::wheel-0.33.0-py37_0
  xarray             conda-forge/linux-64::xarray-0.11.3-py37_0
  xz                 conda-forge/linux-64::xz-5.2.4-h14c3975_1001
  yaml               conda-forge/linux-64::yaml-0.1.7-h14c3975_1001
  zict               conda-forge/noarch::zict-0.1.3-py_0
  zlib               conda-forge/linux-64::zlib-1.2.11-h14c3975_1004
```

Deps after:

```

  backcall           conda-forge/noarch::backcall-0.1.0-py_0
  blas               conda-forge/linux-64::blas-1.1-openblas
  bzip2              conda-forge/linux-64::bzip2-1.0.6-h14c3975_1002
  ca-certificates    conda-forge/linux-64::ca-certificates-2018.11.29-ha4d7672_0
  certifi            conda-forge/linux-64::certifi-2018.11.29-py37_1000
  cftime             conda-forge/linux-64::cftime-1.0.3.4-py37h3010b51_1000
  curl               conda-forge/linux-64::curl-7.64.0-h646f8bb_0
  decorator          conda-forge/noarch::decorator-4.3.2-py_0
  geojson            conda-forge/noarch::geojson-2.4.1-py_0
  hdf4               conda-forge/linux-64::hdf4-4.2.13-h9a582f1_1002
  hdf5               conda-forge/linux-64::hdf5-1.10.4-nompi_h11e915b_1105
  ipython            conda-forge/linux-64::ipython-7.2.0-py37h24bf2e0_1000
  ipython_genutils   conda-forge/noarch::ipython_genutils-0.2.0-py_1
  jedi               conda-forge/linux-64::jedi-0.13.2-py37_1000
  jpeg               conda-forge/linux-64::jpeg-9c-h14c3975_1001
  krb5               conda-forge/linux-64::krb5-1.16.3-hc83ff2d_1000
  libcurl            conda-forge/linux-64::libcurl-7.64.0-h01ee5af_0
  libedit            conda-forge/linux-64::libedit-3.1.20170329-hf8c457e_1001
  libffi             conda-forge/linux-64::libffi-3.2.1-hf484d3e_1005
  libgcc-ng          conda-forge/linux-64::libgcc-ng-7.3.0-hdf63c60_0
  libgfortran-ng     conda-forge/linux-64::libgfortran-ng-7.2.0-hdf63c60_3
  libnetcdf          conda-forge/linux-64::libnetcdf-4.6.2-hbdf4f91_1001
  libssh2            conda-forge/linux-64::libssh2-1.8.0-h1ad7b7a_1003
  libstdcxx-ng       conda-forge/linux-64::libstdcxx-ng-7.3.0-hdf63c60_0
  ncurses            conda-forge/linux-64::ncurses-6.1-hf484d3e_1002
  netcdf4            conda-forge/linux-64::netcdf4-1.4.2-py37had69b76_1001
  numpy              conda-forge/linux-64::numpy-1.16.1-py37_blas_openblash1522bff_0
  openblas           conda-forge/linux-64::openblas-0.3.3-h9ac9557_1001
  openssl            conda-forge/linux-64::openssl-1.0.2p-h14c3975_1002
  pandas             conda-forge/linux-64::pandas-0.24.1-py37hf484d3e_0
  parso              conda-forge/noarch::parso-0.3.4-py_0
  pexpect            conda-forge/linux-64::pexpect-4.6.0-py37_1000
  pickleshare        conda-forge/linux-64::pickleshare-0.7.5-py37_1000
  pip                conda-forge/linux-64::pip-19.0.2-py37_0
  prompt_toolkit     conda-forge/noarch::prompt_toolkit-2.0.8-py_0
  ptyprocess         conda-forge/linux-64::ptyprocess-0.6.0-py37_1000
  pygc               conda-forge/noarch::pygc-1.2.1-py_1
  pygments           conda-forge/noarch::pygments-2.3.1-py_0
  python             conda-forge/linux-64::python-3.7.1-hd21baee_1001
  python-dateutil    conda-forge/noarch::python-dateutil-2.8.0-py_0
  pytz               conda-forge/noarch::pytz-2018.9-py_0
  readline           conda-forge/linux-64::readline-7.0-hf8c457e_1001
  ruamel.yaml        conda-forge/linux-64::ruamel.yaml-0.15.88-py37h14c3975_0
  setuptools         conda-forge/linux-64::setuptools-40.8.0-py37_0
  simplejson         conda-forge/linux-64::simplejson-3.16.0-py37h14c3975_1002
  six                conda-forge/linux-64::six-1.12.0-py37_1000
  sqlite             conda-forge/linux-64::sqlite-3.26.0-h67949de_1000
  tk                 conda-forge/linux-64::tk-8.6.9-h84994c4_1000
  traitlets          conda-forge/linux-64::traitlets-4.3.2-py37_1000
  wcwidth            conda-forge/noarch::wcwidth-0.1.7-py_1
  wheel              conda-forge/linux-64::wheel-0.33.0-py37_0
  xarray             conda-forge/linux-64::xarray-0.11.3-py37_0
  xz                 conda-forge/linux-64::xz-5.2.4-h14c3975_1001
  zlib               conda-forge/linux-64::zlib-1.2.11-h14c3975_1004
```

I used `conda create --dry-run -n ioos_qc_37 python=3.7 --file requirements.txt ` to determine deps.