### PR TITLE
Use range of previous values (ptp or peak-to-peak) as alternative flat_line_test

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -458,6 +458,8 @@ def flat_line_test(inp: Sequence[N],
         return out
 
     # convert time thresholds to number of observations
+    if not len(tinp):
+        return np.ma.array([])
     time_interval = np.median(np.diff(tinp)).astype(float)
     counts = (int(suspect_threshold), int(fail_threshold)) / time_interval
     counts = span(*sorted(counts.astype(int)))
@@ -539,6 +541,8 @@ def flat_line_test_ptp(inp: Sequence[N],
         return out
 
     # convert time thresholds to number of observations
+    if not len(tinp):
+        return np.ma.array([])
     time_interval = np.median(np.diff(tinp)).astype(float)
     counts = (int(suspect_threshold), int(fail_threshold)) / time_interval
     counts = span(*sorted(counts.astype(int)))

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -77,10 +77,10 @@ def qartod_compare(vectors : Sequence[Sequence[N]]
     return result
 
 
-def location_test(lon : Sequence[N],
-                  lat : Sequence[N],
-                  bbox : Tuple[N, N, N, N] = (-180, -90, 180, 90),
-                  range_max : N = None
+def location_test(lon: Sequence[N],
+                  lat: Sequence[N],
+                  bbox: Tuple[N, N, N, N] = (-180, -90, 180, 90),
+                  range_max: N = None
                   ) -> np.ma.core.MaskedArray:
     """Checks that a location is within reasonable bounds.
 
@@ -154,9 +154,9 @@ def location_test(lon : Sequence[N],
     return flag_arr.reshape(original_shape)
 
 
-def gross_range_test(inp : Sequence[N],
-                     fail_span : Tuple[N, N],
-                     suspect_span : Tuple[N, N] = None
+def gross_range_test(inp: Sequence[N],
+                     fail_span: Tuple[N, N],
+                     suspect_span: Tuple[N, N] = None
                      ) -> np.ma.core.MaskedArray:
     """Checks that values are within reasonable range bounds.
 
@@ -235,9 +235,9 @@ class ClimatologyConfig(object):
         return span
 
     def add(self,
-            tspan : Tuple[N, N],
-            vspan : Tuple[N, N],
-            zspan : Tuple[N, N] = None) -> None:
+            tspan: Tuple[N, N],
+            vspan: Tuple[N, N],
+            zspan: Tuple[N, N] = None) -> None:
 
         assert isfixedlength(tspan, 2)
         tspan = mapdates(tspan)
@@ -259,10 +259,10 @@ class ClimatologyConfig(object):
         )
 
 
-def climatology_test(config : Union[ClimatologyConfig, Sequence[Dict[str, Tuple]]],
-                     inp : Sequence[N],
-                     tinp : Sequence[N],
-                     zinp : Sequence[N],
+def climatology_test(config: Union[ClimatologyConfig, Sequence[Dict[str, Tuple]]],
+                     inp: Sequence[N],
+                     tinp: Sequence[N],
+                     zinp: Sequence[N],
                      ) -> np.ma.core.MaskedArray:
     """Checks that values are within reasonable range bounds and flags as SUSPECT.
 
@@ -272,6 +272,7 @@ def climatology_test(config : Union[ClimatologyConfig, Sequence[Dict[str, Tuple]
         config: A ClimatologyConfig object or a list of dicts containing tuples
             that can be used to create a ClimatologyConfig object. Dict should be composed of
             keywords 'tspan' and 'vspan' as well as an optional 'zspan'
+        inp:  Input data as a numeric numpy array or a list of numbers.
         tinp: Time data as a numpy array of dtype `datetime64`, or seconds as type `int`.
         vinp: Input data as a numeric numpy array or a list of numbers.
         zinp: Z (depth) data as a numeric numpy array or a list of numbers.
@@ -319,7 +320,7 @@ def climatology_test(config : Union[ClimatologyConfig, Sequence[Dict[str, Tuple]
     return flag_arr.reshape(original_shape)
 
 
-def spike_test(inp : Sequence[N],
+def spike_test(inp: Sequence[N],
                suspect_threshold: N,
                fail_threshold: N
                ) -> np.ma.core.MaskedArray:
@@ -375,9 +376,9 @@ def spike_test(inp : Sequence[N],
     return flag_arr.reshape(original_shape)
 
 
-def rate_of_change_test(inp : Sequence[N],
-                        tinp : Sequence[N],
-                        threshold : float
+def rate_of_change_test(inp: Sequence[N],
+                        tinp: Sequence[N],
+                        threshold: float
                         ) -> np.ma.core.MaskedArray:
     """Checks the first order difference of a series of values to see if
     there are any values exceeding a threshold defined by the inputs.
@@ -419,11 +420,11 @@ def rate_of_change_test(inp : Sequence[N],
     return flag_arr.reshape(original_shape)
 
 
-def flat_line_test(inp : Sequence[N],
+def flat_line_test(inp: Sequence[N],
                    tinp: Sequence[N],
                    suspect_threshold: int,
                    fail_threshold: int,
-                   tolerance : N = 0
+                   tolerance: N = 0
                    ) -> np.ma.MaskedArray:
     """Check for consecutively repeated values within a tolerance.
 
@@ -491,9 +492,9 @@ def flat_line_test(inp : Sequence[N],
     return flag_arr.reshape(original_shape)
 
 
-def attenuated_signal_test(inp : Sequence[N],
-                           threshold : Tuple[N, N],
-                           check_type : str = 'std'
+def attenuated_signal_test(inp: Sequence[N],
+                           threshold: Tuple[N, N],
+                           check_type: str = 'std'
                            ) -> np.ma.MaskedArray:
     """Check for near-flat-line conditions using a range or standard deviation.
 

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -272,7 +272,7 @@ def climatology_test(config : Union[ClimatologyConfig, Sequence[Dict[str, Tuple]
         config: A ClimatologyConfig object or a list of dicts containing tuples
             that can be used to create a ClimatologyConfig object. Dict should be composed of
             keywords 'tspan' and 'vspan' as well as an optional 'zspan'
-        tinp: Time data as a numpy array of dtype `datetime64`.
+        tinp: Time data as a numpy array of dtype `datetime64`, or seconds as type `int`.
         vinp: Input data as a numeric numpy array or a list of numbers.
         zinp: Z (depth) data as a numeric numpy array or a list of numbers.
 
@@ -388,7 +388,7 @@ def rate_of_change_test(inp : Sequence[N],
 
     Args:
         inp: Input data as a numeric numpy array or a list of numbers.
-        tinp: Time data as a numpy array of dtype `datetime64`.
+        tinp: Time data as a numpy array of dtype `datetime64`, or seconds as type `int`.
         threshold: A float value representing a rate of change over time,
                  in observation units per second.
 
@@ -431,7 +431,7 @@ def flat_line_test(inp : Sequence[N],
 
     Args:
         inp: Input data as a numeric numpy array or a list of numbers.
-        tinp: Time data as a numpy array of dtype `datetime64`.
+        tinp: Time data as a numpy array of dtype `datetime64`, or seconds as type `int`.
         suspect_threshold: The number of seconds within `tolerance` to
             allow before being flagged as SUSPECT.
         fail_threshold: The number of seconds within `tolerance` to
@@ -474,15 +474,15 @@ def flat_line_test(inp : Sequence[N],
     suspect_chunks = chunk(inp, counts.minv)
     suspect_data = np.repeat(inp, counts.minv).reshape(inp.size, counts.minv)
     with np.errstate(invalid='ignore'):
-        suspect_test = np.all(np.abs((suspect_chunks - suspect_data)) < tolerance, axis=1)
-        suspect_test = np.ma.filled(suspect_test, fill_value=False)
+        suspect_test = np.ma.filled(np.abs((suspect_chunks - suspect_data)) < tolerance, fill_value=False)
+        suspect_test = np.all(suspect_test, axis=1)
         flag_arr[suspect_test] = QartodFlags.SUSPECT
 
     fail_chunks = chunk(inp, counts.maxv)
     failed_data = np.repeat(inp, counts.maxv).reshape(inp.size, counts.maxv)
     with np.errstate(invalid='ignore'):
-        failed_test = np.all(np.abs((fail_chunks - failed_data)) < tolerance, axis=1)
-        failed_test = np.ma.filled(failed_test, fill_value=False)
+        failed_test = np.ma.filled(np.abs((fail_chunks - failed_data)) < tolerance, fill_value=False)
+        failed_test = np.all(failed_test, axis=1)
         flag_arr[failed_test] = QartodFlags.FAIL
 
     # If the value is masked set the flag to MISSING

--- a/tests/test_flt_simple.py
+++ b/tests/test_flt_simple.py
@@ -38,7 +38,7 @@ def test_all():
                 'fail_threshold': 4,
                 'expected': [1, 1, 1, 1, 1]
                 }
-    # check_flat_line_test(all_pass, flt_eld_envelope.flat_line_test_eld)
+    check_flat_line_test(all_pass, qartod.flat_line_test_ptp)
     check_flat_line_test(all_pass, qartod.flat_line_test)
 
     # this config produces 1 suspect point both tests
@@ -49,7 +49,7 @@ def test_all():
                'fail_threshold': 4,
                'expected': [1, 1, 3, 1, 1]
                }
-    # check_flat_line_test(suspect, flt_eld_envelope.flat_line_test_eld)
+    check_flat_line_test(suspect, qartod.flat_line_test_ptp)
     check_flat_line_test(suspect, qartod.flat_line_test)
 
     # this config produces 1 failed point both tests
@@ -60,7 +60,7 @@ def test_all():
                'fail_threshold': 4,
                'expected': [1, 1, 3, 3, 4]
                }
-    # check_flat_line_test(failing, flt_eld_envelope.flat_line_test_eld)
+    check_flat_line_test(failing, qartod.flat_line_test_ptp)
     check_flat_line_test(failing, qartod.flat_line_test)
 
     # this config produces different answers depending on the test used, so 'expected' must be adjusted.
@@ -71,7 +71,7 @@ def test_all():
                'fail_threshold': 6,
                'expected': [1, 1, 1, 3, 3, 1, 1, 1, 3, 3]
                }
-    # check_flat_line_test(failing, flt_eld_envelope.flat_line_test_eld)
+    check_flat_line_test(failing, qartod.flat_line_test_ptp)
     # the original test produces fails on the right side of the bump because those points are mid-way between the
     # extremes to the peak and valley, so don't exceed the tolerance
     failing['expected'] = [1, 1, 1, 3, 3, 1, 1, 4, 4, 3]

--- a/tests/test_flt_simple.py
+++ b/tests/test_flt_simple.py
@@ -1,0 +1,78 @@
+"""
+These are very simple tests to assess the behavior of flat_line_test under controlled conditions. This may be a
+temporary tool to define the differences between the original flat_line_test that employs difference, and an
+alternate version that employs np.ptp (peak-to-peak, or range). If parts are more generally useful, they should be
+integrated into test_qartod.py.
+
+ELD
+6/27/2019
+"""
+
+import numpy.testing as npt
+from ioos_qc import qartod as qartod
+
+
+def check_flat_line_test(config, flt):
+    """ Call flat_line_test with a defined set of arguments to compare answers given by different versions of the test
+
+    :param config: Dictionary full of arguments for the flat line test
+    :param flt: the flat line test you want to use for the test
+    :return: nothing
+    """
+    results = flt(inp=config['value'],
+                  tinp=config['time'],
+                  tolerance=config['tolerance'],
+                  suspect_threshold=config['suspect_threshold'],
+                  fail_threshold=config['fail_threshold']
+                  )
+    npt.assert_array_equal(results, config['expected'])
+
+
+def test_all():
+
+    # this config completely passes both tests
+    all_pass = {'time': [1, 2, 3, 4, 5],
+                'value': [1, 2, 3, 4, 5],
+                'tolerance': 0.9,
+                'suspect_threshold': 2,
+                'fail_threshold': 4,
+                'expected': [1, 1, 1, 1, 1]
+                }
+    # check_flat_line_test(all_pass, flt_eld_envelope.flat_line_test_eld)
+    check_flat_line_test(all_pass, qartod.flat_line_test)
+
+    # this config produces 1 suspect point both tests
+    suspect = {'time': [1, 2, 3, 4, 5],
+               'value': [1, 1, 1, 4, 5],
+               'tolerance': 0.9,
+               'suspect_threshold': 2,
+               'fail_threshold': 4,
+               'expected': [1, 1, 3, 1, 1]
+               }
+    # check_flat_line_test(suspect, flt_eld_envelope.flat_line_test_eld)
+    check_flat_line_test(suspect, qartod.flat_line_test)
+
+    # this config produces 1 failed point both tests
+    failing = {'time': [1, 2, 3, 4, 5],
+               'value': [1, 1, 1, 1, 1],
+               'tolerance': 0.9,
+               'suspect_threshold': 2,
+               'fail_threshold': 4,
+               'expected': [1, 1, 3, 3, 4]
+               }
+    # check_flat_line_test(failing, flt_eld_envelope.flat_line_test_eld)
+    check_flat_line_test(failing, qartod.flat_line_test)
+
+    # this config produces different answers depending on the test used, so 'expected' must be adjusted.
+    failing = {'time': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+               'value': [1, 1, 1, 1, 1, 6, 5, 4, 3, 2],
+               'tolerance': 4,
+               'suspect_threshold': 3,
+               'fail_threshold': 6,
+               'expected': [1, 1, 1, 3, 3, 1, 1, 1, 3, 3]
+               }
+    # check_flat_line_test(failing, flt_eld_envelope.flat_line_test_eld)
+    # the original test produces fails on the right side of the bump because those points are mid-way between the
+    # extremes to the peak and valley, so don't exceed the tolerance
+    failing['expected'] = [1, 1, 1, 3, 3, 1, 1, 4, 4, 3]
+    check_flat_line_test(failing, qartod.flat_line_test)

--- a/tests/test_flt_simple.py
+++ b/tests/test_flt_simple.py
@@ -109,7 +109,7 @@ def test_flat_line_starting_from_beginning():
 
 def test_empty_array():
 
-    # test empty array - should return empty result
+    # test empty array - should return empty result (like the original test in test_qartod)
     empty = {'time': [1, 2, 3, 4, 5],
              'value': np.array([]),
              'tolerance': 0.9,
@@ -120,8 +120,7 @@ def test_empty_array():
     check_flat_line_test(empty, qartod.flat_line_test_ptp)
     check_flat_line_test(empty, qartod.flat_line_test)
 
-    # Note, time cannot be empty or it fails when trying to make suspect_chunks (no masked array with negative
-    # dimensions)  A problem for another day?
+    # also works if time is an empty array
     empty = {'time': np.array([]),
              'value': np.array([]),
              'tolerance': 0.9,
@@ -129,6 +128,6 @@ def test_empty_array():
              'fail_threshold': 4,
              'expected': np.array([])
              }
-    # check_flat_line_test(empty, qartod.flat_line_test_ptp)
+    check_flat_line_test(empty, qartod.flat_line_test_ptp)
     check_flat_line_test(empty, qartod.flat_line_test)
 

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -620,7 +620,7 @@ class QartodFlatLineTest(unittest.TestCase):
         npt.assert_array_equal(
             qartod.flat_line_test(
                 inp=arr,
-                tinp=self.times,
+                tinp=arr,
                 suspect_threshold=self.suspect_threshold,
                 fail_threshold=self.fail_threshold,
                 tolerance=self.tolerance


### PR DESCRIPTION
I started with the flat_line_test bugfix branch and added an alternative version of the test that uses the range of values rather than  individual differences.

To test it, I used a separate test that really simplified the arrays so I could see what was going on. The main goal of test_flt_simple.py is to compare the behavior of the 2 tests, not to test every possible input. If those tests are useful, they could be integrated somehow into test_qartod.py.  Note: the only difference in behavior that I could find was for the bump, where the original test failed points on the right side of the bump, and the new test didn't.

Also, some comments were clarified, and a few changes made to better adhere to PEP8. Otherwise, I tried to change as little as I could.